### PR TITLE
Loosen pinning of runtime gems

### DIFF
--- a/solargraph-standardrb.gemspec
+++ b/solargraph-standardrb.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "solargraph", "~> 0.39.1"
-  spec.add_runtime_dependency "standard", "~> 0.4.1"
+  spec.add_runtime_dependency "solargraph", ">= 0.39.1"
+  spec.add_runtime_dependency "standard", ">= 0.4.1", "< 1.0.0"
 end


### PR DESCRIPTION
Allows for a wider version of the runtime gems to be used while avoiding potential breaking changes in their versions.